### PR TITLE
Add slick-duckdb entry to claims.json

### DIFF
--- a/claims.json
+++ b/claims.json
@@ -341,6 +341,7 @@
   "com.github.ahjohannessen akka-etcd*": "ahjohannessen/akka-etcd",
   "com.github.akileev akka-serial-io_*": "akileev/akka-serial-io",
   "com.github.alexarchambault sbt-notebook": "alexarchambault/sbt-notebook",
+  "com.github.algebrazebra slick-duckdb_*": "algebrazebra/slick-duckdb",
   "com.github.alixba vast_*": "AlixBa/vast",
   "com.github.andyglow scalax-xml-diff_*": "andyglow/scala-xml-diff",
   "com.github.bolthelmet mockito-sugar-rush*": "Bolthelmet/mockito-sugar-rush",


### PR DESCRIPTION
Adding my project, because it's not picked up automatically.
Maven Sonatype release has the Scala binary version information in the name and a POM with a url to my Github repository.

EDIT: Sonatype release for reference: https://central.sonatype.com/artifact/io.github.algebrazebra/slick-duckdb_2.13