### PR TITLE
Add typesafe-config-yaml dependency to non-standard.json

### DIFF
--- a/non-standard.json
+++ b/non-standard.json
@@ -43,5 +43,6 @@
   "org.sorm-framework sorm":                         "pom",
   "com.github.mauricio postgresql-async_2.10":       "pom",
   "com.github.mauricio postgresql-async_2.11":       "pom",
-  "com.github.mauricio postgresql-async_2.12":       "pom"
+  "com.github.mauricio postgresql-async_2.12":       "pom",
+  "io.h8 typesafe-config-yaml":                      "pom"
 }


### PR DESCRIPTION
The artefact in maven-central: https://central.sonatype.com/artifact/io.h8/typesafe-config-yaml/overview

POM: https://repo1.maven.org/maven2/io/h8/typesafe-config-yaml/1.0.0/typesafe-config-yaml-1.0.0.pom

This is a Java artifact, but it is intended for Typesafe Config / Lightbend Config users. Typesafe Config is widely used in the Scala ecosystem, so I would like this library to be discoverable on Scaladex despite not having a Scala binary suffix.